### PR TITLE
Fixing broken build

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -202,7 +202,7 @@ apps:
       - browser-support
   folding-at-home-fcole90:
     command: usr/bin/FAHClient -v --chdir $SNAP_USER_COMMON
-    autostart: "$SNAP/meta/gui/FAHClientAutostart.desktop"
+    autostart: "$SNAP/meta/gui/folding-at-home-fcole90.desktop"
     environment:
     
       LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/:/var/lib/snapd/hostfs/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/"


### PR DESCRIPTION
```
Issues while validating snapcraft.yaml: The 'apps/folding-at-home-fcole90/autostart' property does not match the required schema: '$SNAP/meta/gui/FAHClientAutostart.desktop' is not a valid desktop file name (e.g. myapp.desktop)
```